### PR TITLE
Safe api

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SwiftPackageIndex/ShellQuote",
         "state": {
           "branch": null,
-          "revision": "31432fc1ef1000dce11109b9543dd88fd0819d22",
-          "version": "1.0.0"
+          "revision": "e0f831805ad70c5bc9f34c293d445826ff50c3b4",
+          "version": "1.0.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,7 +1,15 @@
 {
   "object": {
     "pins": [
-
+      {
+        "package": "ShellQuote",
+        "repositoryURL": "https://github.com/SwiftPackageIndex/ShellQuote",
+        "state": {
+          "branch": null,
+          "revision": "31432fc1ef1000dce11109b9543dd88fd0819d22",
+          "version": "1.0.0"
+        }
+      }
     ]
   },
   "version": 1

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SwiftPackageIndex/ShellQuote",
         "state": {
           "branch": null,
-          "revision": "e0f831805ad70c5bc9f34c293d445826ff50c3b4",
-          "version": "1.0.1"
+          "revision": "5f555550c30ef43d64b36b40c2c291a95d62580c",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,15 @@ let package = Package(
     products: [
         .library(name: "ShellOut", targets: ["ShellOut"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/SwiftPackageIndex/ShellQuote", from: "1.0.0"),
+    ],
     targets: [
         .target(
             name: "ShellOut",
+            dependencies: [
+                .product(name: "ShellQuote", package: "ShellQuote")
+            ],
             path: "Sources"
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "ShellOut", targets: ["ShellOut"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SwiftPackageIndex/ShellQuote", from: "1.0.0"),
+        .package(url: "https://github.com/SwiftPackageIndex/ShellQuote", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "ShellOut", targets: ["ShellOut"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SwiftPackageIndex/ShellQuote", from: "1.0.1"),
+        .package(url: "https://github.com/SwiftPackageIndex/ShellQuote", from: "1.0.2"),
     ],
     targets: [
         .target(

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -2,15 +2,15 @@ public enum Argument {
     case quoted(QuotedString)
     case verbatim(String)
 
-    init(quoted string: String) {
+    public init(quoted string: String) {
         self = .quoted(.init(string))
     }
 
-    init(verbatim string: String) {
+    public init(verbatim string: String) {
         self = .verbatim(string)
     }
 
-    var string: String {
+    public var string: String {
         switch self {
             case let .quoted(value):
                 return value.quoted

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -47,7 +47,7 @@ extension String {
 }
 
 
-extension Array<String> {
+extension Array where Element == String {
     public var quoted: [Argument] { map(\.quoted) }
     public var verbatim: [Argument] { map(\.verbatim) }
 }

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -21,6 +21,11 @@ public enum Argument {
 }
 
 
+extension Argument: CustomStringConvertible {
+    public var description: String { string }
+}
+
+
 extension String {
     public var quoted: Argument { .init(quoted: self) }
     public var verbatim: Argument { .init(verbatim: self) }

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -22,12 +22,12 @@ public enum Argument {
 
 
 extension String {
-    var quoted: Argument { .init(quoted: self) }
-    var verbatim: Argument { .init(verbatim: self) }
+    public var quoted: Argument { .init(quoted: self) }
+    public var verbatim: Argument { .init(verbatim: self) }
 }
 
 
 extension Array<String> {
-    var quoted: [Argument] { map(\.quoted) }
-    var verbatim: [Argument] { map(\.verbatim) }
+    public var quoted: [Argument] { map(\.quoted) }
+    public var verbatim: [Argument] { map(\.verbatim) }
 }

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -1,15 +1,6 @@
 public enum Argument {
-    case safe(SafeString)
     case quoted(QuotedString)
     case verbatim(String)
-
-    init(safe string: String) throws {
-        self = try .safe(.init(string))
-    }
-
-    init(_ string: SafeString) {
-        self = .safe(string)
-    }
 
     init(quoted string: String) {
         self = .quoted(.init(string))
@@ -21,8 +12,6 @@ public enum Argument {
 
     var string: String {
         switch self {
-            case let .safe(value):
-                return value.value
             case let .quoted(value):
                 return value.quoted
             case let .verbatim(string):
@@ -40,9 +29,5 @@ extension String {
 
 extension Array<String> {
     var quoted: [Argument] { map(\.quoted) }
-
-    @available(*, deprecated)
-    func safe() throws -> [Argument] { try map(Argument.init(safe:)) }
-
     var verbatim: [Argument] { map(\.verbatim) }
 }

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -1,0 +1,48 @@
+public enum Argument {
+    case safe(SafeString)
+    case quoted(QuotedString)
+    case verbatim(String)
+
+    init(safe string: String) throws {
+        self = try .safe(.init(string))
+    }
+
+    init(_ string: SafeString) {
+        self = .safe(string)
+    }
+
+    init(quoted string: String) {
+        self = .quoted(.init(string))
+    }
+
+    init(verbatim string: String) {
+        self = .verbatim(string)
+    }
+
+    var string: String {
+        switch self {
+            case let .safe(value):
+                return value.value
+            case let .quoted(value):
+                return value.quoted
+            case let .verbatim(string):
+                return string
+        }
+    }
+}
+
+
+extension String {
+    var quoted: Argument { .init(quoted: self) }
+    var verbatim: Argument { .init(verbatim: self) }
+}
+
+
+extension Array<String> {
+    var quoted: [Argument] { map(\.quoted) }
+
+    @available(*, deprecated)
+    func safe() throws -> [Argument] { try map(Argument.init(safe:)) }
+
+    var verbatim: [Argument] { map(\.verbatim) }
+}

--- a/Sources/Argument.swift
+++ b/Sources/Argument.swift
@@ -1,3 +1,6 @@
+import Foundation
+
+
 public enum Argument {
     case quoted(QuotedString)
     case verbatim(String)
@@ -21,8 +24,20 @@ public enum Argument {
 }
 
 
+extension Argument: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        self = .quoted(.init(value))
+    }
+}
+
+
 extension Argument: CustomStringConvertible {
     public var description: String { string }
+}
+
+
+extension Argument {
+    public static func url(_ url: URL) -> Self { url.absoluteString.verbatim }
 }
 
 

--- a/Sources/QuotedString.swift
+++ b/Sources/QuotedString.swift
@@ -1,0 +1,17 @@
+import ShellQuote
+
+
+public struct QuotedString {
+    public var unquoted: String
+    public var quoted: String
+
+    public init(_ value: String) {
+        self.unquoted = value
+        self.quoted = ShellQuote.quote(value)
+    }
+}
+
+
+extension QuotedString: CustomStringConvertible {
+    public var description: String { quoted }
+}

--- a/Sources/SafeString.swift
+++ b/Sources/SafeString.swift
@@ -22,7 +22,7 @@ extension SafeString: CustomStringConvertible {
 
 
 extension String {
-    var safe: SafeString {
+    var checked: SafeString {
         get throws { try .init(self) }
     }
     var unchecked: SafeString { .init(unchecked: self) }

--- a/Sources/SafeString.swift
+++ b/Sources/SafeString.swift
@@ -1,0 +1,29 @@
+import ShellQuote
+
+
+public struct SafeString {
+    public var value: String
+
+    public init(_ value: String) throws {
+        guard !ShellQuote.hasUnsafeContent(value) else {
+            throw ShellOutCommand.Error(message: "Command must not contain characters that require quoting, was: \(value)")
+        }
+        self.value = value
+    }
+
+    public init(unchecked value: String) {
+        self.value = value
+    }
+}
+
+extension SafeString: CustomStringConvertible {
+    public var description: String { value }
+}
+
+
+extension String {
+    var safe: SafeString {
+        get throws { try .init(self) }
+    }
+    var unchecked: SafeString { .init(unchecked: self) }
+}

--- a/Sources/SafeString.swift
+++ b/Sources/SafeString.swift
@@ -22,8 +22,8 @@ extension SafeString: CustomStringConvertible {
 
 
 extension String {
-    var checked: SafeString {
+    public var checked: SafeString {
         get throws { try .init(self) }
     }
-    var unchecked: SafeString { .init(unchecked: self) }
+    public var unchecked: SafeString { .init(unchecked: self) }
 }

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -40,7 +40,7 @@ import ShellQuote
     quoteArguments: Bool = true
 ) throws -> String {
     guard !ShellQuote.hasUnsafeContent(command) else {
-        throw ShellOutCommand.Error(message: "Command must not contain characters that require quoting.")
+        throw ShellOutCommand.Error(message: "Command must not contain characters that require quoting, was: \(command)")
     }
     let arguments = quoteArguments ? arguments.map(ShellQuote.quote) : arguments
     let command = "cd \(path.escapingSpaces) && \(command) \(arguments.joined(separator: " "))"

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Dispatch
+import ShellQuote
 
 // MARK: - API
 
@@ -35,8 +36,11 @@ import Dispatch
     process: Process = .init(),
     outputHandle: FileHandle? = nil,
     errorHandle: FileHandle? = nil,
-    environment: [String : String]? = nil
+    environment: [String : String]? = nil,
+    quoteArguments: Bool = true
 ) throws -> String {
+    let arguments = quoteArguments ? arguments.map(ShellQuote.quote) : arguments
+    print("*** arguments: ", arguments)
     let command = "cd \(path.escapingSpaces) && \(command) \(arguments.joined(separator: " "))"
 
     return try process.launchBash(

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -39,8 +39,10 @@ import ShellQuote
     environment: [String : String]? = nil,
     quoteArguments: Bool = true
 ) throws -> String {
+    guard !ShellQuote.hasUnsafeContent(command) else {
+        throw ShellOutCommand.Error(message: "Command must not contain characters that require quoting.")
+    }
     let arguments = quoteArguments ? arguments.map(ShellQuote.quote) : arguments
-    print("*** arguments: ", arguments)
     let command = "cd \(path.escapingSpaces) && \(command) \(arguments.joined(separator: " "))"
 
     return try process.launchBash(
@@ -404,6 +406,13 @@ extension ShellOutError: CustomStringConvertible {
 extension ShellOutError: LocalizedError {
     public var errorDescription: String? {
         return description
+    }
+}
+
+extension ShellOutCommand {
+    // TODO: consolidate with ShellOutError
+    struct Error: Swift.Error {
+        var message: String
     }
 }
 

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -101,24 +101,24 @@ public struct ShellOutCommand {
         self.arguments = arguments
     }
 
-    var string: String {
+    public var string: String {
         ([command.value] + arguments.map(\.string))
             .joined(separator: " ")
     }
 
-    func appending(arguments newArguments: [Argument]) -> Self {
+    public func appending(arguments newArguments: [Argument]) -> Self {
         .init(command: command, arguments: arguments + newArguments)
     }
 
-    func appending(argument: Argument) -> Self {
+    public func appending(argument: Argument) -> Self {
         appending(arguments: [argument])
     }
 
-    mutating func append(arguments newArguments: [Argument]) {
+    public mutating func append(arguments newArguments: [Argument]) {
         self.arguments = self.arguments + newArguments
     }
 
-    mutating func append(argument: Argument) {
+    public mutating func append(argument: Argument) {
         append(arguments: [argument])
     }
 }

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -54,44 +54,6 @@ import ShellQuote
 }
 
 /**
- *  Run a series of shell commands using Bash
- *
- *  - parameter commands: The commands to run
- *  - parameter path: The path to execute the commands at (defaults to current folder)
- *  - parameter process: Which process to use to perform the command (default: A new one)
- *  - parameter outputHandle: Any `FileHandle` that any output (STDOUT) should be redirected to
- *              (at the moment this is only supported on macOS)
- *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
- *              (at the moment this is only supported on macOS)
- *  - parameter environment: The environment for the command.
- *
- *  - returns: The output of running the command
- *  - throws: `ShellOutError` in case the command couldn't be performed, or it returned an error
- *
- *  Use this function to "shell out" in a Swift script or command line tool
- *  For example: `shellOut(to: ["mkdir NewFolder", "cd NewFolder"], at: "~/CurrentFolder")`
- */
-@discardableResult public func shellOut(
-    to commands: [String],
-    at path: String = ".",
-    process: Process = .init(),
-    outputHandle: FileHandle? = nil,
-    errorHandle: FileHandle? = nil,
-    environment: [String : String]? = nil
-) throws -> String {
-    let command = commands.joined(separator: " && ")
-
-    return try shellOut(
-        to: command,
-        at: path,
-        process: process,
-        outputHandle: outputHandle,
-        errorHandle: errorHandle,
-        environment: environment
-    )
-}
-
-/**
  *  Run a pre-defined shell command using Bash
  *
  *  - parameter command: The command to run

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -215,4 +215,14 @@ class ShellOutTests: XCTestCase {
                                     arguments: ["foo ; echo bar".verbatim]),
                        "foo\nbar")
     }
+
+    func test_Argument_ExpressibleByStringLiteral() throws {
+        XCTAssertEqual(("foo" as Argument).string, "foo")
+        XCTAssertEqual(("foo bar" as Argument).string, "'foo bar'")
+    }
+
+    func test_Argument_url() throws {
+        XCTAssertEqual(Argument.url(.init(string: "https://example.com")!).string,
+                       "https://example.com")
+    }
 }

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -45,26 +45,6 @@ class ShellOutTests: XCTestCase {
         XCTAssertFalse(homeContents.isEmpty)
     }
 
-    func testSeriesOfCommands() throws {
-        let echo = try shellOut(to: ["echo \"Hello\"", "echo \"world\""])
-        XCTAssertEqual(echo, "Hello\nworld")
-    }
-
-    func testSeriesOfCommandsAtPath() throws {
-        try shellOut(to: [
-            "cd \(NSTemporaryDirectory())",
-            "mkdir -p ShellOutTests",
-            "echo \"Hello again\" > ShellOutTests/MultipleCommands.txt"
-        ])
-
-        let textFileContent = try shellOut(to: [
-            "cd ShellOutTests",
-            "cat MultipleCommands.txt"
-        ], at: NSTemporaryDirectory())
-
-        XCTAssertEqual(textFileContent, "Hello again")
-    }
-
     func testThrowingError() {
         do {
             try shellOut(to: "cd", arguments: ["notADirectory"])

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -174,4 +174,9 @@ class ShellOutTests: XCTestCase {
         try shellOut(to: .generateSwiftPackageXcodeProject(), at: packagePath)
         XCTAssertTrue(try shellOut(to: "ls -a", at: packagePath).contains("SwiftPackageManagerTest.xcodeproj"))
     }
+
+    func testArgumentQuoting() throws {
+        XCTAssertEqual(try shellOut(to: "echo", arguments: ["foo ; echo bar"]), "foo ; echo bar")
+        XCTAssertEqual(try shellOut(to: "echo", arguments: ["foo ; echo bar"], quoteArguments: false), "foo\nbar")
+    }
 }

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -32,23 +32,23 @@ class ShellOutTests: XCTestCase {
     }
 
     func testWithoutArguments() throws {
-        let uptime = try shellOut(to: "uptime".safe)
+        let uptime = try shellOut(to: "uptime".checked)
         XCTAssertTrue(uptime.contains("load average"))
     }
 
     func testWithArguments() throws {
-        let echo = try shellOut(to: "echo".safe, arguments: ["Hello world".quoted])
+        let echo = try shellOut(to: "echo".checked, arguments: ["Hello world".quoted])
         XCTAssertEqual(echo, "Hello world")
     }
 
     func testSingleCommandAtPath() throws {
         try shellOut(
-            to: "echo".safe,
+            to: "echo".checked,
             arguments: [#"Hello" > \#(NSTemporaryDirectory())ShellOutTests-SingleCommand.txt"#.quoted]
         )
 
         let textFileContent = try shellOut(
-            to: "cat".safe,
+            to: "cat".checked,
             arguments:  ["ShellOutTests-SingleCommand.txt".quoted],
             at: NSTemporaryDirectory()
         )
@@ -57,26 +57,26 @@ class ShellOutTests: XCTestCase {
     }
 
     func testSingleCommandAtPathContainingSpace() throws {
-        try shellOut(to: "mkdir".safe,
+        try shellOut(to: "mkdir".checked,
                      arguments: ["-p".verbatim, "ShellOut Test Folder".quoted],
                      at: NSTemporaryDirectory())
-        try shellOut(to: "echo".safe, arguments: ["Hello",  ">",  "File"].verbatim,
+        try shellOut(to: "echo".checked, arguments: ["Hello",  ">",  "File"].verbatim,
                      at: NSTemporaryDirectory() + "ShellOut Test Folder")
 
         let output = try shellOut(
-            to: "cat".safe,
+            to: "cat".checked,
             arguments: ["\(NSTemporaryDirectory())ShellOut Test Folder/File".quoted])
         XCTAssertEqual(output, "Hello")
     }
 
     func testSingleCommandAtPathContainingTilde() throws {
-        let homeContents = try shellOut(to: "ls".safe, at: "~")
+        let homeContents = try shellOut(to: "ls".checked, at: "~")
         XCTAssertFalse(homeContents.isEmpty)
     }
 
     func testThrowingError() {
         do {
-            try shellOut(to: "cd".safe, arguments: ["notADirectory".verbatim])
+            try shellOut(to: "cd".checked, arguments: ["notADirectory".verbatim])
             XCTFail("Expected expression to throw")
         } catch let error as ShellOutError {
             XCTAssertTrue(error.message.contains("notADirectory"))
@@ -110,7 +110,7 @@ class ShellOutTests: XCTestCase {
 
     func testCapturingOutputWithHandle() throws {
         let pipe = Pipe()
-        let output = try shellOut(to: "echo".safe,
+        let output = try shellOut(to: "echo".checked,
                                   arguments: ["Hello".verbatim],
                                   outputHandle: pipe.fileHandleForWriting)
         let capturedData = pipe.fileHandleForReading.readDataToEndOfFile()
@@ -122,7 +122,7 @@ class ShellOutTests: XCTestCase {
         let pipe = Pipe()
 
         do {
-            try shellOut(to: "cd".safe,
+            try shellOut(to: "cd".checked,
                          arguments: ["notADirectory".verbatim],
                          errorHandle: pipe.fileHandleForWriting)
             XCTFail("Expected expression to throw")
@@ -149,10 +149,10 @@ class ShellOutTests: XCTestCase {
     func testGitCommands() throws {
         // Setup & clear state
         let tempFolderPath = NSTemporaryDirectory()
-        try shellOut(to: "rm".safe,
+        try shellOut(to: "rm".checked,
                      arguments: ["-rf", "GitTestOrigin"].verbatim,
                      at: tempFolderPath)
-        try shellOut(to: "rm".safe,
+        try shellOut(to: "rm".checked,
                      arguments: ["-rf", "GitTestClone"].verbatim,
                      at: tempFolderPath)
 
@@ -183,7 +183,7 @@ class ShellOutTests: XCTestCase {
     func testSwiftPackageManagerCommands() throws {
         // Setup & clear state
         let tempFolderPath = NSTemporaryDirectory()
-        try shellOut(to: "rm".safe,
+        try shellOut(to: "rm".checked,
                      arguments: ["-rf", "SwiftPackageManagerTest"].verbatim,
                      at: tempFolderPath)
         try shellOut(to: .createFolder(named: "SwiftPackageManagerTest"), at: tempFolderPath)
@@ -196,22 +196,22 @@ class ShellOutTests: XCTestCase {
         // Build the package and verify that there's a .build folder
         try shellOut(to: .buildSwiftPackage(), at: packagePath)
         XCTAssertTrue(
-            try shellOut(to: "ls".safe, arguments: ["-a".verbatim], at: packagePath) .contains(".build")
+            try shellOut(to: "ls".checked, arguments: ["-a".verbatim], at: packagePath) .contains(".build")
         )
 
         // Generate an Xcode project
         try shellOut(to: .generateSwiftPackageXcodeProject(), at: packagePath)
         XCTAssertTrue(
-            try shellOut(to: "ls".safe, arguments: ["-a".verbatim], at: packagePath)
+            try shellOut(to: "ls".checked, arguments: ["-a".verbatim], at: packagePath)
                 .contains("SwiftPackageManagerTest.xcodeproj")
         )
     }
 
     func testArgumentQuoting() throws {
-        XCTAssertEqual(try shellOut(to: "echo".safe,
+        XCTAssertEqual(try shellOut(to: "echo".checked,
                                     arguments: ["foo ; echo bar".quoted]),
                        "foo ; echo bar")
-        XCTAssertEqual(try shellOut(to: "echo".safe,
+        XCTAssertEqual(try shellOut(to: "echo".checked,
                                     arguments: ["foo ; echo bar".verbatim]),
                        "foo\nbar")
     }

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -18,25 +18,24 @@ class ShellOutTests: XCTestCase {
         XCTAssertEqual(echo, "Hello world")
     }
 
-    func testWithInlineArguments() throws {
-        let echo = try shellOut(to: "echo \"Hello world\"")
-        XCTAssertEqual(echo, "Hello world")
-    }
-
     func testSingleCommandAtPath() throws {
-        try shellOut(to: "echo \"Hello\" > \(NSTemporaryDirectory())ShellOutTests-SingleCommand.txt")
+        try shellOut(to: "echo", arguments: [#"Hello" > \#(NSTemporaryDirectory())ShellOutTests-SingleCommand.txt"#])
 
-        let textFileContent = try shellOut(to: "cat ShellOutTests-SingleCommand.txt",
+        let textFileContent = try shellOut(to: "cat",
+                                           arguments:  ["ShellOutTests-SingleCommand.txt"],
                                            at: NSTemporaryDirectory())
 
         XCTAssertEqual(textFileContent, "Hello")
     }
 
     func testSingleCommandAtPathContainingSpace() throws {
-        try shellOut(to: "mkdir -p \"ShellOut Test Folder\"", at: NSTemporaryDirectory())
-        try shellOut(to: "echo \"Hello\" > File", at: NSTemporaryDirectory() + "ShellOut Test Folder")
+        try shellOut(to: "mkdir", arguments: ["-p", "ShellOut Test Folder"],
+                     at: NSTemporaryDirectory())
+        try shellOut(to: "echo", arguments: ["Hello",  ">",  "File"],
+                     at: NSTemporaryDirectory() + "ShellOut Test Folder")
 
-        let output = try shellOut(to: "cat \(NSTemporaryDirectory())ShellOut\\ Test\\ Folder/File")
+        let output = try shellOut(to: "cat",
+                                  arguments: ["\(NSTemporaryDirectory())ShellOut Test Folder/File"])
         XCTAssertEqual(output, "Hello")
     }
 
@@ -108,8 +107,8 @@ class ShellOutTests: XCTestCase {
     func testGitCommands() throws {
         // Setup & clear state
         let tempFolderPath = NSTemporaryDirectory()
-        try shellOut(to: "rm -rf GitTestOrigin", at: tempFolderPath)
-        try shellOut(to: "rm -rf GitTestClone", at: tempFolderPath)
+        try shellOut(to: "rm", arguments: ["-rf", "GitTestOrigin"], at: tempFolderPath)
+        try shellOut(to: "rm", arguments: ["-rf", "GitTestClone"], at: tempFolderPath)
 
         // Create a origin repository and make a commit with a file
         let originPath = tempFolderPath + "/GitTestOrigin"
@@ -138,7 +137,9 @@ class ShellOutTests: XCTestCase {
     func testSwiftPackageManagerCommands() throws {
         // Setup & clear state
         let tempFolderPath = NSTemporaryDirectory()
-        try shellOut(to: "rm -rf SwiftPackageManagerTest", at: tempFolderPath)
+        try shellOut(to: "rm",
+                     arguments: ["-rf", "SwiftPackageManagerTest"],
+                     at: tempFolderPath)
         try shellOut(to: .createFolder(named: "SwiftPackageManagerTest"), at: tempFolderPath)
 
         // Create a Swift package and verify that it has a Package.swift file


### PR DESCRIPTION
The basic change here is to make all commands adhere to a pattern `command` + `arguments`, like `Process`, with some control over whether `arguments` are being quoted or not. The default is to always quote and to always reject a `command` that isn't safe.

This ensure that you can't accidentally end up building a command string that's open to shell injection.

To do:

- [ ] update docs